### PR TITLE
Add filename option to debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.log
 node_modules/
+.idea

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = function (debug) {
   this.filter("sass", (data, options) => {
     return this.defer(sass)(
       assign({ data: data.toString() },
-      assign({ outFile: options.sourceMap ? "." : "" }, options))
+      assign({ outFile: options.sourceMap ? "." : "", file: options.filename }, options))
     ).then((result) => assign({ ext: ".css" }, result))
   })
 }


### PR DESCRIPTION
Thanks for creating this wrapper, i use it every day ;)

To debug more easily I have added the name of the current file being `sassified` :smile: 

Previous error report : 

![selection_198](https://cloud.githubusercontent.com/assets/1492516/9567616/ef241a3c-4f32-11e5-9992-2fe7dcea44a8.png)

After the correction :

![selection_199](https://cloud.githubusercontent.com/assets/1492516/9567617/f8389c9c-4f32-11e5-93d3-c49e654dbcf3.png)

`Fly version is 0.8.2 I don't know if you care about that...`
